### PR TITLE
Added git ignore config, and ignored .DS_Store files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
The invisible file named .DS_Store is automatically created by Windows. This file creates unnecessary clutter in the repository. Adding it to the gitignore file tells Git to not archive these files in the repository, when present.